### PR TITLE
fix(release): build release notes from CHANGELOG.md, not the commit log

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,38 +105,70 @@ jobs:
           echo "name=$(node -p "require('./package.json').name")" >> $GITHUB_OUTPUT
           echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
-      - name: Generate changelog
+      - name: Generate release notes
         id: changelog
+        env:
+          VERSION: ${{ steps.package.outputs.version }}
+          PACKAGE_NAME: ${{ steps.package.outputs.name }}
         run: |
-          # Get previous tag
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
-          CURRENT_TAG="v${{ steps.package.outputs.version }}"
+          set -euo pipefail
 
-          echo "## Changes" > CHANGELOG.md
+          # Prefer the curated CHANGELOG.md entry for this version — that is what
+          # readers actually need on a release, especially the breaking changes.
+          # Pull out everything between "## <version>" and the next "## " heading.
+          # The version is escaped first so its dots are not treated as regex
+          # wildcards (3.0.0 must not match 3x0y0).
+          awk -v ver="$VERSION" '
+            BEGIN { gsub(/\./, "\\.", ver) }
+            $0 ~ "^## +" ver "([[:space:]]|$)" { capture = 1; next }
+            capture && /^## / { exit }
+            capture { print }
+          ' CHANGELOG.md > section.md || true
 
-          if [ -n "$PREV_TAG" ]; then
-            echo "" >> CHANGELOG.md
-            git log $PREV_TAG..HEAD --pretty=format:"- %s (%h)" --no-merges >> CHANGELOG.md
+          # Trim leading and trailing blank lines from the extracted section.
+          sed -i -e '/./,$!d' section.md
+          sed -i -e :a -e '/^\n*$/{$d;N;ba' -e '}' section.md
+
+          if [ -s section.md ]; then
+            echo "Using CHANGELOG.md entry for $VERSION"
+            {
+              echo "## Changes"
+              echo ""
+              cat section.md
+            } > RELEASE_NOTES.md
           else
-            echo "- Initial release" >> CHANGELOG.md
+            # No curated entry for this version — fall back to the commit log so a
+            # release still gets notes rather than an empty body.
+            echo "No CHANGELOG.md entry for $VERSION; falling back to commit log"
+            PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
+
+            echo "## Changes" > RELEASE_NOTES.md
+            if [ -n "$PREV_TAG" ]; then
+              echo "" >> RELEASE_NOTES.md
+              git log "$PREV_TAG"..HEAD --pretty=format:"- %s (%h)" --no-merges >> RELEASE_NOTES.md
+              echo "" >> RELEASE_NOTES.md
+            else
+              echo "- Initial release" >> RELEASE_NOTES.md
+            fi
           fi
 
-          echo "" >> CHANGELOG.md
-          echo "## Installation" >> CHANGELOG.md
-          echo "" >> CHANGELOG.md
-          echo '```bash' >> CHANGELOG.md
-          echo "npm install ${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }}" >> CHANGELOG.md
-          echo '```' >> CHANGELOG.md
+          {
+            echo ""
+            echo "## Installation"
+            echo ""
+            echo '```bash'
+            echo "npm install ${PACKAGE_NAME}@${VERSION}"
+            echo '```'
+          } >> RELEASE_NOTES.md
 
-          # Output for GitHub release
-          cat CHANGELOG.md >> $GITHUB_STEP_SUMMARY
+          cat RELEASE_NOTES.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.package.outputs.version }}
           name: Release v${{ steps.package.outputs.version }}
-          body_path: CHANGELOG.md
+          body_path: RELEASE_NOTES.md
           draft: false
           prerelease: ${{ contains(steps.package.outputs.version, '-') }}
 


### PR DESCRIPTION
Blocks nothing, but worth landing before the v3.0.0 publish.

## Problem

`create-release` overwrote `CHANGELOG.md` in its checkout with a `git log` since the previous tag and used that as the GitHub release body. For v3.0.0 that yields ~5 bullets — the squashed v3 commit plus four dependabot bumps — and drops every word of the curated changelog, including the breaking-change notices for the removed V1 surface and Twitter enhancement layer.

## Change

Extract the `## <version>` section out of `CHANGELOG.md` and use that as the release body. Falls back to the commit log when there's no entry for the version, so a release never gets an empty body. Writes to `RELEASE_NOTES.md` instead of clobbering the real changelog in the working tree.

The version is regex-escaped before matching, so `3.0.0` can't match `3x0y0`.

## Verification

Ran the extraction against the real `CHANGELOG.md` — it produces the full Added / Removed / Changed sections for 3.0.0 followed by the install snippet. Also checked the fallback triggers for a version with no entry, the dot-escaping rejects a false match, and the workflow still parses as YAML.

## Note for the release itself

Unrelated to this PR, but relevant when publishing: the workflow's `push: tags` trigger can't work. `publish` declares `environment: production`, whose deployment policy allows only the `dev` and `main` **branches** — a tag ref matches no rule and the job would be blocked at the environment gate. Every one of the last ten releases used `workflow_dispatch` from `main`, which is the path that actually works. Worth either adding a tag policy or dropping the dead trigger in a follow-up.