### PR TITLE
ci(release): publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,16 +53,34 @@ jobs:
     needs: validate
     environment: production
 
+    # Trusted publishing (OIDC) — no long-lived NPM_TOKEN. npm mints a
+    # short-lived credential from the id-token, and the trust relationship is
+    # configured on npmjs.com against this repo, this workflow filename and the
+    # `production` environment above. Changing any of those three breaks
+    # publishing until the npm-side config is updated to match.
+    permissions:
+      id-token: write # required for OIDC
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      # Trusted publishing requires Node >= 22.14.0 and npm >= 11.5.1. Node 20
+      # ships npm 10.x, which does not understand OIDC publishing. This only
+      # sets the runner's toolchain — the package still targets node >= 18 per
+      # `engines`, and the build output is unaffected.
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Install dependencies
         run: npm ci
@@ -70,14 +88,11 @@ jobs:
       - name: Build package
         run: npm run build
 
+      # No NODE_AUTH_TOKEN: npm detects the OIDC credential itself. Provenance
+      # attestations are generated automatically under trusted publishing, so
+      # --provenance is not needed.
       - name: Publish to NPM
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          # Configure npm
-          npm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
-
-          # Publish package
           npm publish --access public
 
           echo "✅ Package published successfully"

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check for required secrets
         run: |
           echo "📋 Required secrets for workflows:"
-          echo "- NPM_TOKEN (for publishing to npm)"
+          echo "- (npm publishing uses OIDC trusted publishing — no token needed)"
           echo "- ELFA_API_KEY (for integration tests)"
           echo "- TWITTER_API_KEY (for integration tests)"
           echo ""

--- a/AGENT.md
+++ b/AGENT.md
@@ -109,11 +109,10 @@ keep matching the workflow:
 | Environment name  | `production`  |
 
 Renaming the workflow file or the `production` environment breaks publishing
-until the npm-side config is updated to match. Publishing requires Node
-
-> = 22.14.0 and npm >= 11.5.1, which is why the publish job pins a newer Node than
-> the test matrix and upgrades npm before publishing. Provenance attestations are
-> generated automatically; `--provenance` is not needed.
+until the npm-side config is updated to match. Publishing requires
+`Node >= 22.14.0` and `npm >= 11.5.1`, which is why the publish job pins a newer
+Node than the test matrix and upgrades npm before publishing. Provenance
+attestations are generated automatically; `--provenance` is not needed.
 
 If publishing ever fails with `npm error 404 ... PUT`, that is an auth failure,
 not a missing package — npm withholds 401/403 so it does not disclose whether a

--- a/AGENT.md
+++ b/AGENT.md
@@ -97,10 +97,27 @@ policy allows only the `dev` and `main` branches. A tag ref matches no branch ru
 so a tag-triggered run is blocked at the environment gate. Every release to date
 has used `workflow_dispatch`.
 
-`NPM_TOKEN` lives on the `production` **environment**, not in repo secrets — a
-plain `gh secret set` puts it in the wrong place. An expired token surfaces as
-`npm error 404 ... PUT`, which is npm's way of reporting an auth failure without
-disclosing whether the package exists.
+**Publishing uses OIDC trusted publishing — there is no npm token.** npm mints a
+short-lived credential from the workflow's id-token, so nothing needs rotating.
+The trust relationship is configured on npmjs.com against three values that must
+keep matching the workflow:
+
+| npm setting       | Value         |
+| ----------------- | ------------- |
+| Repository        | `elfa-sdk-js` |
+| Workflow filename | `release.yml` |
+| Environment name  | `production`  |
+
+Renaming the workflow file or the `production` environment breaks publishing
+until the npm-side config is updated to match. Publishing requires Node
+
+> = 22.14.0 and npm >= 11.5.1, which is why the publish job pins a newer Node than
+> the test matrix and upgrades npm before publishing. Provenance attestations are
+> generated automatically; `--provenance` is not needed.
+
+If publishing ever fails with `npm error 404 ... PUT`, that is an auth failure,
+not a missing package — npm withholds 401/403 so it does not disclose whether a
+package exists.
 
 ## Security Considerations
 


### PR DESCRIPTION
Yes, separate PR — this is a workflow change, independent of the AGENT.md fixes in #72.

Trusted publishing replaces the long-lived `NPM_TOKEN` with a short-lived credential npm mints from the workflow's OIDC id-token. The token that failed the 3.0.0 release had gone stale; this removes that failure mode entirely, and leaves no secret to rotate or leak.

## ⚠️ Configure npm first, then merge

Merging before the npm-side config exists will make the next release fail. Values for **Settings → Trusted Publisher** on the `@elfa-ai/sdk` package page:

| Field | Value |
| --- | --- |
| Publisher | `GitHub Actions` |
| Organization or user | `elfa-ai` |
| Repository | `elfa-sdk-js` |
| Workflow filename | `release.yml` |
| Environment name | `production` |
| Allowed actions | `npm publish` |

Workflow filename is **filename only**, not a path — no `.github/workflows/` prefix. Environment must be `production` because that's what the publish job declares; those two values plus the repo are load-bearing, and renaming either breaks publishing until npm is updated to match.

## Changes

- `id-token: write` on the publish job, scoped to that job alongside `contents: read`. Other jobs keep workflow defaults.
- Publish runner Node 20 → 24. Trusted publishing requires **Node >= 22.14.0 and npm >= 11.5.1**, and Node 20 ships npm 10.x, which doesn't understand OIDC publishing. Runner toolchain only — `engines` still declares `node >= 18`, the CI test matrix is untouched, and the build output is unchanged.
- Explicit `npm install -g npm@latest`, since even Node 24 doesn't ship 11.5.1+ yet.
- Removed `NODE_AUTH_TOKEN` and the `npm config set _authToken` line. npm detects the OIDC credential itself.
- Removed the stale `NPM_TOKEN` line from `validate-workflows.yml`.

`--provenance` is deliberately not added: under trusted publishing npm generates provenance attestations by default, so the package gains a verified supply-chain link to this repo and commit for free.

## After this lands

The `NPM_TOKEN` secret on the `production` environment becomes dead weight and can be deleted. Worth also switching **Publishing access** to *"Require two-factor authentication and disallow tokens"* — npm notes it stays compatible with trusted publishers, and it closes off token-based publishing for good.

## Verification

All four workflows parse as YAML and are prettier-clean. Confirmed the publish job resolves to environment `production`, permissions `{id-token: write, contents: read}`, Node `24.x`, and a publish step with no `env:` block. Requirements checked against [npm's trusted publishers docs](https://docs.npmjs.com/trusted-publishers/) rather than memory.