### PR TITLE
fix: propagate updateOptions to internal clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `updateOptions()` now propagates to the internal clients. Previously it only
+  mutated the object returned by `getOptions()`, so changes to `debug`,
+  `timeout`, `retries`, `retryDelay`, `headers`, `baseUrl` and `hmacSecret`
+  never reached the HTTP layer — e.g. `updateOptions({ debug: false })` left
+  request/response logging on.
+
 ## 3.0.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.0.1
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elfa-ai/sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elfa-ai/sdk",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elfa-ai/sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Official TypeScript SDK for the Elfa API v2 - social intelligence, AI chat, and the Auto/Trade engines for crypto",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/__tests__/AutoClient.test.ts
+++ b/src/__tests__/AutoClient.test.ts
@@ -12,6 +12,7 @@ describe("AutoClient", () => {
       post: jest.fn(),
       delete: jest.fn(),
       setAuthHeader: jest.fn(),
+      updateOptions: jest.fn(),
     } as any;
     (HttpClient as jest.MockedClass<typeof HttpClient>).mockImplementation(
       () => mockHttpClient,
@@ -29,6 +30,31 @@ describe("AutoClient", () => {
       expiresIn: "1h",
     },
   };
+
+  it("applies updateOptions to signing and the http client", async () => {
+    const client = new AutoClient({ apiKey: "k" });
+    mockHttpClient.post.mockResolvedValue({ valid: true });
+
+    client.updateOptions({
+      hmacSecret: "secret",
+      baseUrl: "https://staging.api.elfa.ai",
+      debug: true,
+    });
+
+    expect(mockHttpClient.updateOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: "https://staging.api.elfa.ai",
+        debug: true,
+      }),
+    );
+
+    await client.createQuery(eql);
+
+    const [, , config] = mockHttpClient.post.mock.calls[0];
+    expect(config?.headers).toEqual(
+      expect.objectContaining({ "x-elfa-signature": expect.any(String) }),
+    );
+  });
 
   it("posts validateQuery unsigned", async () => {
     const client = new AutoClient({ apiKey: "k" });

--- a/src/__tests__/ElfaSDK.test.ts
+++ b/src/__tests__/ElfaSDK.test.ts
@@ -24,6 +24,7 @@ describe("ElfaSDK", () => {
       getTrendingNarratives: jest.fn(),
       chat: jest.fn(),
       testConnection: jest.fn(),
+      updateOptions: jest.fn(),
     } as any;
 
     (ElfaV2Client as jest.MockedClass<typeof ElfaV2Client>).mockImplementation(
@@ -175,6 +176,21 @@ describe("ElfaSDK", () => {
       const sdk = new ElfaSDK({ elfaApiKey: "k" });
       sdk.updateOptions({ debug: true });
       expect(sdk.getOptions().debug).toBe(true);
+    });
+
+    it("updateOptions propagates to every client", () => {
+      const sdk = new ElfaSDK({ elfaApiKey: "k", debug: true });
+
+      sdk.updateOptions({ debug: false, timeout: 5000 });
+
+      const expected = expect.objectContaining({
+        apiKey: "k",
+        debug: false,
+        timeout: 5000,
+      });
+      expect(mockElfaClient.updateOptions).toHaveBeenCalledWith(expected);
+      expect(sdk.auto.updateOptions).toHaveBeenCalledWith(expected);
+      expect(sdk.trade.updateOptions).toHaveBeenCalledWith(expected);
     });
   });
 });

--- a/src/__tests__/ElfaV2Client.test.ts
+++ b/src/__tests__/ElfaV2Client.test.ts
@@ -17,6 +17,7 @@ describe("ElfaV2Client", () => {
       delete: jest.fn(),
       setAuthHeader: jest.fn(),
       setTwitterAuthHeader: jest.fn(),
+      updateOptions: jest.fn(),
       request: jest.fn(),
     } as any;
 
@@ -57,6 +58,21 @@ describe("ElfaV2Client", () => {
         baseURL: "https://custom.api.com",
         timeout: 5000,
         retries: 1,
+        debug: true,
+      });
+    });
+  });
+
+  describe("updateOptions", () => {
+    it("should forward merged options to the http client", () => {
+      client.updateOptions({ debug: true, timeout: 5000 });
+
+      expect(mockHttpClient.updateOptions).toHaveBeenCalledWith({
+        baseURL: "https://api.elfa.ai",
+        timeout: 5000,
+        retries: 3,
+        retryDelay: undefined,
+        headers: undefined,
         debug: true,
       });
     });

--- a/src/__tests__/HttpClient.test.ts
+++ b/src/__tests__/HttpClient.test.ts
@@ -212,10 +212,18 @@ describe("HttpClient", () => {
       );
     });
 
-    it("should apply retry settings to subsequent requests", async () => {
+    it("should ignore undefined values and apply retry settings", async () => {
       const { NetworkError } = await import("../utils/errors");
       mockAxiosInstance.request.mockRejectedValue(new NetworkError("boom"));
 
+      httpClient.updateOptions({ retries: undefined });
+
+      await expect(
+        httpClient.request({ url: "/test", method: "GET", retryDelay: 0 }),
+      ).rejects.toThrow("boom");
+      expect(mockAxiosInstance.request).toHaveBeenCalledTimes(3);
+
+      mockAxiosInstance.request.mockClear();
       httpClient.updateOptions({ retries: 0 });
 
       await expect(

--- a/src/__tests__/HttpClient.test.ts
+++ b/src/__tests__/HttpClient.test.ts
@@ -178,6 +178,53 @@ describe("HttpClient", () => {
     });
   });
 
+  describe("updateOptions", () => {
+    it("should toggle request logging without recreating the client", () => {
+      const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+      const onRequest =
+        mockAxiosInstance.interceptors.request.use.mock.calls[0][0];
+
+      httpClient.updateOptions({ debug: true });
+      onRequest({ method: "get", url: "/v2/ping" });
+      expect(logSpy).toHaveBeenCalled();
+
+      logSpy.mockClear();
+      httpClient.updateOptions({ debug: false });
+      onRequest({ method: "get", url: "/v2/ping" });
+      expect(logSpy).not.toHaveBeenCalled();
+
+      logSpy.mockRestore();
+    });
+
+    it("should apply baseURL, timeout and headers to the axios defaults", () => {
+      httpClient.updateOptions({
+        baseURL: "https://staging.api.example.com",
+        timeout: 1234,
+        headers: { "x-custom": "value" },
+      });
+
+      expect(mockAxiosInstance.defaults.baseURL).toBe(
+        "https://staging.api.example.com",
+      );
+      expect(mockAxiosInstance.defaults.timeout).toBe(1234);
+      expect(mockAxiosInstance.defaults.headers.common["x-custom"]).toBe(
+        "value",
+      );
+    });
+
+    it("should apply retry settings to subsequent requests", async () => {
+      const { NetworkError } = await import("../utils/errors");
+      mockAxiosInstance.request.mockRejectedValue(new NetworkError("boom"));
+
+      httpClient.updateOptions({ retries: 0 });
+
+      await expect(
+        httpClient.request({ url: "/test", method: "GET", retryDelay: 0 }),
+      ).rejects.toThrow("boom");
+      expect(mockAxiosInstance.request).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("error handling", () => {
     let handleResponseError: (error: AxiosError) => Promise<never>;
 

--- a/src/__tests__/TradeClient.test.ts
+++ b/src/__tests__/TradeClient.test.ts
@@ -12,6 +12,7 @@ describe("TradeClient", () => {
       post: jest.fn(),
       delete: jest.fn(),
       setAuthHeader: jest.fn(),
+      updateOptions: jest.fn(),
     } as any;
     (HttpClient as jest.MockedClass<typeof HttpClient>).mockImplementation(
       () => mockHttpClient,
@@ -60,6 +61,24 @@ describe("TradeClient", () => {
         "x-elfa-timestamp": expect.any(String),
         "x-elfa-signature": expect.any(String),
       }),
+    );
+  });
+
+  it("applies updateOptions to signing and the http client", async () => {
+    const client = new TradeClient({ apiKey: "k" });
+    mockHttpClient.post.mockResolvedValue({ success: true });
+
+    client.updateOptions({ hmacSecret: "secret", debug: true });
+
+    expect(mockHttpClient.updateOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ debug: true }),
+    );
+
+    await client.placeOrder(order);
+
+    const [, , config] = mockHttpClient.post.mock.calls[0];
+    expect(config?.headers).toEqual(
+      expect.objectContaining({ "x-elfa-signature": expect.any(String) }),
     );
   });
 

--- a/src/client/AutoClient.ts
+++ b/src/client/AutoClient.ts
@@ -65,6 +65,23 @@ export class AutoClient {
     this.httpClient.setAuthHeader(this.apiKey);
   }
 
+  public updateOptions(
+    options: Partial<Omit<AutoClientOptions, "apiKey">>,
+  ): void {
+    if (options.baseUrl !== undefined) this.baseUrl = options.baseUrl;
+    if (options.hmacSecret !== undefined) this.hmacSecret = options.hmacSecret;
+    if (options.headers !== undefined) this.headers = options.headers;
+
+    this.httpClient.updateOptions({
+      baseURL: this.baseUrl,
+      timeout: options.timeout,
+      retries: options.retries,
+      retryDelay: options.retryDelay,
+      headers: this.headers,
+      debug: options.debug,
+    });
+  }
+
   public chat(params: AutoChatParams): Promise<AutoChatResponse> {
     return this.post<AutoChatResponse>("/chat", params);
   }

--- a/src/client/ElfaSDK.ts
+++ b/src/client/ElfaSDK.ts
@@ -45,7 +45,15 @@ export class ElfaSDK {
       ...options,
     };
 
-    const clientOptions = {
+    const clientOptions = this.buildClientOptions();
+
+    this.elfaClient = new ElfaV2Client(clientOptions);
+    this.auto = new AutoClient(clientOptions);
+    this.trade = new TradeClient(clientOptions);
+  }
+
+  private buildClientOptions() {
+    return {
       apiKey: this.options.elfaApiKey,
       baseUrl: this.options.baseUrl,
       timeout: this.options.timeout,
@@ -57,10 +65,6 @@ export class ElfaSDK {
         : {}),
       ...(this.options.headers ? { headers: this.options.headers } : {}),
     };
-
-    this.elfaClient = new ElfaV2Client(clientOptions);
-    this.auto = new AutoClient(clientOptions);
-    this.trade = new TradeClient(clientOptions);
   }
 
   private validateOptions(options: SDKOptions): void {
@@ -159,5 +163,11 @@ export class ElfaSDK {
     }
 
     this.options = { ...this.options, ...newOptions };
+
+    const clientOptions = this.buildClientOptions();
+
+    this.elfaClient.updateOptions(clientOptions);
+    this.auto.updateOptions(clientOptions);
+    this.trade.updateOptions(clientOptions);
   }
 }

--- a/src/client/ElfaV2Client.ts
+++ b/src/client/ElfaV2Client.ts
@@ -74,6 +74,21 @@ export class ElfaV2Client {
     this.httpClient.setAuthHeader(this.options.apiKey);
   }
 
+  public updateOptions(
+    options: Partial<Omit<ElfaV2ClientOptions, "apiKey">>,
+  ): void {
+    this.options = { ...this.options, ...options };
+
+    this.httpClient.updateOptions({
+      baseURL: this.options.baseUrl,
+      timeout: this.options.timeout,
+      retries: this.options.retries,
+      retryDelay: this.options.retryDelay,
+      headers: this.options.headers,
+      debug: this.options.debug,
+    });
+  }
+
   private validateTimeWindowOrFromTo(params: {
     timeWindow?: string;
     from?: number;

--- a/src/client/TradeClient.ts
+++ b/src/client/TradeClient.ts
@@ -41,6 +41,21 @@ export class TradeClient {
     this.httpClient.setAuthHeader(options.apiKey);
   }
 
+  public updateOptions(
+    options: Partial<Omit<TradeClientOptions, "apiKey">>,
+  ): void {
+    if (options.hmacSecret !== undefined) this.hmacSecret = options.hmacSecret;
+
+    this.httpClient.updateOptions({
+      baseURL: options.baseUrl,
+      timeout: options.timeout,
+      retries: options.retries,
+      retryDelay: options.retryDelay,
+      headers: options.headers,
+      debug: options.debug,
+    });
+  }
+
   public previewOrder(input: PlaceOrderInput): Promise<TradePreviewResponse> {
     return this.post("/orders/preview", input);
   }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -178,7 +178,10 @@ export class HttpClient {
   }
 
   public updateOptions(options: Partial<HttpClientOptions>): void {
-    this.options = { ...this.options, ...options };
+    const patch = Object.fromEntries(
+      Object.entries(options).filter(([, value]) => value !== undefined),
+    );
+    this.options = { ...this.options, ...patch };
 
     if (options.baseURL !== undefined) {
       this.client.defaults.baseURL = options.baseURL;

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -177,6 +177,22 @@ export class HttpClient {
     return this.request<T>({ ...config, method: "DELETE", url });
   }
 
+  public updateOptions(options: Partial<HttpClientOptions>): void {
+    this.options = { ...this.options, ...options };
+
+    if (options.baseURL !== undefined) {
+      this.client.defaults.baseURL = options.baseURL;
+    }
+
+    if (options.timeout !== undefined) {
+      this.client.defaults.timeout = options.timeout;
+    }
+
+    if (options.headers !== undefined) {
+      Object.assign(this.client.defaults.headers.common, options.headers);
+    }
+  }
+
   public setAuthHeader(token: string): void {
     this.client.defaults.headers.common["x-elfa-api-key"] = token;
   }


### PR DESCRIPTION
`updateOptions()` only mutated the SDK's own options object, so the internal clients kept whatever they were constructed with — `updateOptions({ debug: false })` was reflected by `getOptions()` while requests were still logged. Same for `timeout`, `retries`, `retryDelay`, `headers`, `baseUrl` and `hmacSecret`.

Options are now pushed down to `ElfaV2Client`, `AutoClient` and `TradeClient` (and their `HttpClient`s) on every update. `elfaApiKey` still throws. Tests cover each option.
