### PR TITLE
ci: make tag releases work correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,18 @@ jobs:
           npm run build
 
       - name: Validate version
-        if: github.event.inputs.version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          INPUT_VERSION="${{ github.event.inputs.version }}"
-          if [ "$PACKAGE_VERSION" != "$INPUT_VERSION" ]; then
-            echo "❌ Version mismatch: package.json has $PACKAGE_VERSION but input is $INPUT_VERSION"
+          EXPECTED="${INPUT_VERSION:-${TAG_NAME#v}}"
+          if [ "$PACKAGE_VERSION" != "$EXPECTED" ]; then
+            echo "❌ Version mismatch: package.json has $PACKAGE_VERSION but release asks for $EXPECTED"
             exit 1
           fi
-          echo "✅ Version validation passed"
+          echo "✅ Version validation passed for $PACKAGE_VERSION"
 
   publish:
     name: Publish to NPM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24.x"
-          cache: "npm"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Upgrade npm for trusted publishing
         run: |


### PR DESCRIPTION
Closes #85.

Tag releases are now enabled on this repo, so this makes them work correctly.

## 1. npm cache in the publish job

npm's trusted-publishing guidance says not to cache in release builds. Removed with `package-manager-cache: false`. The validate job keeps its cache, which is fine since it does not publish.

## 2. The version check was skipped on tag releases

`Validate version` was gated on `if: github.event.inputs.version`. That input only exists on `workflow_dispatch`, so on a tag push the step was **skipped entirely**.

That meant tagging `v4.0.1` while `package.json` still said `4.0.0` would publish **4.0.0**, and the tag, the npm version and the GitHub release would all disagree — silently.

The check now derives the expected version from whichever trigger fired:

```bash
EXPECTED="${INPUT_VERSION:-${TAG_NAME#v}}"
```

Verified against all three paths:

| Trigger | package.json | Asked for | Result |
| --- | --- | --- | --- |
| `workflow_dispatch` | 4.0.1 | 4.0.1 | accept |
| tag `v4.0.1` | 4.0.1 | 4.0.1 | accept |
| tag `v9.9.9` | 4.0.1 | 9.9.9 | **reject** |

## Environment

The `production` environment now has a Tag rule matching `v*` alongside the existing branch rules, so tag-triggered runs are no longer rejected at the gate. That was why the one tag release attempt, `v3.0.1` on 1 Aug, failed with a publish job that ran zero steps.

## Release process after this

```bash
# bump version in package.json, add a "## X.Y.Z" heading to CHANGELOG.md
git commit -am "chore: release 4.0.1"
git push origin main
git tag v4.0.1 && git push origin v4.0.1
```

validate -> publish via OIDC -> GitHub release generated from the CHANGELOG entry. `workflow_dispatch` still works as before.
