### PR TITLE
fix: type the keyword-mentions cursor as a number

### DIFF
--- a/src/__tests__/PaginationHelper.test.ts
+++ b/src/__tests__/PaginationHelper.test.ts
@@ -4,14 +4,14 @@ describe("PaginationHelper", () => {
   describe("createCursorResult", () => {
     it("should create cursor pagination result with cursor", () => {
       const data = [{ id: 1 }, { id: 2 }];
-      const metadata = { cursor: "next-cursor", total: 100 };
+      const metadata = { cursor: 1785905420000, total: 100 };
 
       const result = PaginationHelper.createCursorResult(data, metadata, 10);
 
       expect(result).toEqual({
         data,
         hasNextPage: true,
-        nextCursor: "next-cursor",
+        nextCursor: 1785905420000,
         totalCount: 100,
       });
     });
@@ -31,14 +31,14 @@ describe("PaginationHelper", () => {
 
     it("should create cursor pagination result without total", () => {
       const data = [{ id: 1 }];
-      const metadata = { cursor: "next-cursor" };
+      const metadata = { cursor: 1785905420000 };
 
       const result = PaginationHelper.createCursorResult(data, metadata);
 
       expect(result).toEqual({
         data,
         hasNextPage: true,
-        nextCursor: "next-cursor",
+        nextCursor: 1785905420000,
       });
     });
   });
@@ -271,5 +271,25 @@ describe("PaginationHelper", () => {
 
       expect(allItems).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
     });
+  });
+});
+
+describe("cursor round-trip", () => {
+  it("stops when the API repeats a cursor the caller supplied as a string", async () => {
+    const fetchPage = jest.fn(async () => ({
+      data: [{ id: 1 }],
+      metadata: { cursor: 1785905420000, total: 1 },
+    }));
+
+    const pages: { id: number }[][] = [];
+    for await (const page of PaginationHelper.iterateCursor(fetchPage, {
+      cursor: "1785905420000",
+    })) {
+      pages.push(page);
+      if (pages.length > 3) break;
+    }
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(pages).toHaveLength(1);
   });
 });

--- a/src/client/ElfaV2Client.ts
+++ b/src/client/ElfaV2Client.ts
@@ -201,8 +201,8 @@ export class ElfaV2Client {
     if (params.searchType) {
       searchParams.append("searchType", params.searchType);
     }
-    if (params.cursor) {
-      searchParams.append("cursor", params.cursor);
+    if (params.cursor !== undefined) {
+      searchParams.append("cursor", String(params.cursor));
     }
     if (params.reposts !== undefined) {
       searchParams.append("reposts", params.reposts.toString());

--- a/src/types/elfa.ts
+++ b/src/types/elfa.ts
@@ -108,7 +108,7 @@ export interface KeywordMentionsV2Response {
   success: boolean;
   data: ProcessedMention[];
   metadata: {
-    cursor?: string;
+    cursor?: number;
     total: number;
   };
 }
@@ -187,7 +187,7 @@ export interface KeywordMentionsParams {
   to?: number;
   limit?: number;
   searchType?: string;
-  cursor?: string;
+  cursor?: string | number;
   reposts?: boolean;
 }
 

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,7 +1,7 @@
 export interface PaginationResult<T> {
   data: T[];
   hasNextPage: boolean;
-  nextCursor?: string;
+  nextCursor?: number;
   nextPage?: number;
   totalCount?: number;
   currentPage?: number;
@@ -9,7 +9,7 @@ export interface PaginationResult<T> {
 }
 
 export interface CursorPaginationParams {
-  cursor?: string;
+  cursor?: string | number;
   limit?: number;
 }
 
@@ -21,7 +21,7 @@ export interface PagePaginationParams {
 export class PaginationHelper {
   public static createCursorResult<T>(
     data: T[],
-    metadata: { cursor?: string; total?: number },
+    metadata: { cursor?: number; total?: number },
     _requestedLimit?: number,
   ): PaginationResult<T> {
     const result: PaginationResult<T> = {
@@ -123,7 +123,7 @@ export class PaginationHelper {
   >(
     fetchPage: (params: TParams) => Promise<{
       data: TResponse[];
-      metadata: { cursor?: string; total?: number };
+      metadata: { cursor?: number; total?: number };
     }>,
     initialParams: TParams,
   ): AsyncGenerator<TResponse[], void, unknown> {
@@ -138,7 +138,7 @@ export class PaginationHelper {
       yield response.data;
 
       const nextCursor = response.metadata.cursor;
-      if (!nextCursor || nextCursor === cursor) {
+      if (!nextCursor || String(nextCursor) === String(cursor)) {
         break;
       }
 
@@ -176,7 +176,7 @@ export class PaginationHelper {
   >(
     fetchPage: (params: TParams) => Promise<{
       data: TResponse[];
-      metadata: { cursor?: string; total?: number };
+      metadata: { cursor?: number; total?: number };
     }>,
     params: TParams,
     maxItems?: number,


### PR DESCRIPTION
Closes #84.

Most of that issue was already fixed by 4.0.0 — `TradeClient` is gone and `chatStream` landed. This is what was left.

## `cursor` is a number, not a string

`keyword-mentions` returns a millisecond timestamp:

```json
"metadata": { "total": 4034, "cursor": 1785905420000 }
```

The API types it as `number` and returns an integer. The SDK declared `cursor?: string`, so anyone doing string operations on it was working by accident.

- `KeywordMentionsV2Response.metadata.cursor` -> `number`
- `PaginationResult.nextCursor` -> `number`
- `KeywordMentionsParams.cursor` -> `string | number`, since the value goes back out as a query param and callers may already hold either
- The client stringifies on the way out, and now uses `!== undefined` rather than truthiness, so a cursor of `0` is no longer dropped

## A latent bug this surfaced

`iterateCursor` terminates on `nextCursor === cursor`. With the response typed as a number and the parameter accepting either, a caller who passes a string cursor would compare `1785905420000 === "1785905420000"`, get `false`, and keep fetching the same page until the API stopped returning a cursor.

Now compared as strings. Regression test added for exactly that case: a string cursor in, a numeric cursor back, one fetch, loop terminates.

## Not included

`/v2/data/market-events` is still absent from the SDK. It is beta, access-gated, and lives in a separate spec file rather than the main one the SDK tracks, so leaving it out may well be deliberate. Happy to add it if it should be there — it did not feel like my call to make silently.

## Testing

132 tests pass, typecheck, lint and build clean. Verified the live response shape against the API before changing anything.
