### PR TITLE
fix(http): honour the rate-limit reset when retrying 429s

### DIFF
--- a/src/__tests__/HttpClient.test.ts
+++ b/src/__tests__/HttpClient.test.ts
@@ -1,9 +1,12 @@
 import axios, { type AxiosError } from "axios";
 import {
   HttpClient,
+  MAX_RATE_LIMIT_WAIT_MS,
   computeRateLimitReset,
   extractErrorMessage,
+  resolveRetryWait,
 } from "../utils/http";
+import { RateLimitError } from "../utils/errors";
 import { VERSION } from "../version";
 
 // Mock axios
@@ -126,6 +129,60 @@ describe("HttpClient", () => {
       ).rejects.toThrow("boom");
 
       expect(mockAxiosInstance.request).toHaveBeenCalledTimes(3);
+    });
+
+    it("should wait for the rate-limit reset instead of the backoff", async () => {
+      const { RateLimitError } = await import("../utils/errors");
+      const resetTime = new Date(Date.now() + 300);
+
+      mockAxiosInstance.request
+        .mockRejectedValueOnce(new RateLimitError("slow down", resetTime))
+        .mockResolvedValue({ data: { success: true } });
+
+      const started = Date.now();
+      const result = await httpClient.request({
+        url: "/test",
+        retries: 1,
+        retryDelay: 1,
+      });
+      const elapsed = Date.now() - started;
+
+      expect(result).toEqual({ success: true });
+      // the 1ms backoff would have retried straight back into the closed window
+      expect(elapsed).toBeGreaterThanOrEqual(250);
+    });
+
+    it("should stop retrying when the reset is further out than we will wait", async () => {
+      const { RateLimitError } = await import("../utils/errors");
+      const resetTime = new Date(Date.now() + 60 * 60 * 1000);
+
+      mockAxiosInstance.request.mockRejectedValue(
+        new RateLimitError("slow down", resetTime),
+      );
+
+      await expect(
+        httpClient.request({ url: "/test", retries: 3, retryDelay: 1 }),
+      ).rejects.toMatchObject({ name: "RateLimitError", resetTime });
+
+      // one attempt only: blocking the caller for an hour is not ours to decide
+      expect(mockAxiosInstance.request).toHaveBeenCalledTimes(1);
+    });
+
+    it("should keep the plain backoff for retryable errors without a reset", async () => {
+      const { NetworkError } = await import("../utils/errors");
+
+      mockAxiosInstance.request
+        .mockRejectedValueOnce(new NetworkError("boom"))
+        .mockResolvedValue({ data: { success: true } });
+
+      const result = await httpClient.request({
+        url: "/test",
+        retries: 1,
+        retryDelay: 0,
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockAxiosInstance.request).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -384,6 +441,42 @@ describe("HttpClient", () => {
         expect(error.resetTime).toBeInstanceOf(Date);
       }
     });
+  });
+});
+
+describe("resolveRetryWait", () => {
+  const now = 1_700_000_000_000;
+
+  it("falls back to the backoff for errors that carry no reset", () => {
+    expect(resolveRetryWait(new Error("boom"), 500, now)).toBe(500);
+  });
+
+  it("falls back to the backoff when a RateLimitError has no resetTime", () => {
+    const error = new RateLimitError("slow down");
+    expect(resolveRetryWait(error, 500, now)).toBe(500);
+  });
+
+  it("honours the reset when it is longer than the backoff", () => {
+    const error = new RateLimitError("slow down", new Date(now + 30000));
+    expect(resolveRetryWait(error, 500, now)).toBe(30000);
+  });
+
+  it("keeps the backoff when the reset has already elapsed", () => {
+    const error = new RateLimitError("slow down", new Date(now - 5000));
+    expect(resolveRetryWait(error, 500, now)).toBe(500);
+  });
+
+  it("gives up when the reset is beyond the maximum wait", () => {
+    const error = new RateLimitError("slow down", new Date(now + 3600000));
+    expect(resolveRetryWait(error, 500, now)).toBeUndefined();
+  });
+
+  it("waits right up to the maximum", () => {
+    const error = new RateLimitError(
+      "slow down",
+      new Date(now + MAX_RATE_LIMIT_WAIT_MS),
+    );
+    expect(resolveRetryWait(error, 500, now)).toBe(MAX_RATE_LIMIT_WAIT_MS);
   });
 });
 

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -27,6 +27,12 @@ export interface RequestConfig extends AxiosRequestConfig {
   retryDelay?: number;
 }
 
+/**
+ * Longest we are willing to sit on a server-provided rate-limit reset before
+ * handing the decision back to the caller via `RateLimitError.resetTime`.
+ */
+export const MAX_RATE_LIMIT_WAIT_MS = 60000;
+
 export class HttpClient {
   private client: AxiosInstance;
   private options: HttpClientOptions;
@@ -137,13 +143,24 @@ export class HttpClient {
           break;
         }
 
+        const wait = resolveRetryWait(
+          lastError,
+          retryDelay * Math.pow(2, attempt),
+        );
+
+        // The server asked us to wait longer than we are willing to block for.
+        // Surface the RateLimitError so the caller can act on `resetTime`.
+        if (wait === undefined) {
+          break;
+        }
+
         if (this.options.debug) {
           console.log(
-            `[HTTP] Retry attempt ${attempt + 1}/${maxRetries} after ${retryDelay}ms`,
+            `[HTTP] Retry attempt ${attempt + 1}/${maxRetries} after ${wait}ms`,
           );
         }
 
-        await this.delay(retryDelay * Math.pow(2, attempt));
+        await this.delay(wait);
       }
     }
 
@@ -252,6 +269,39 @@ export async function throwForFetchResponse(
   }
 
   throw new ElfaApiError(message, response.status, data);
+}
+
+/**
+ * How long to wait before the next attempt.
+ *
+ * A 429 carries the server's own reset hint (`x-ratelimit-reset` or
+ * `Retry-After`), already parsed onto `RateLimitError.resetTime`. Honour it
+ * instead of the blind backoff, otherwise every retry lands inside the window
+ * the server just told us to sit out. Returns `undefined` when the wait exceeds
+ * `maxWaitMs`, meaning: stop retrying and let the caller decide.
+ */
+export function resolveRetryWait(
+  error: Error,
+  backoffMs: number,
+  now: number = Date.now(),
+  maxWaitMs: number = MAX_RATE_LIMIT_WAIT_MS,
+): number | undefined {
+  if (error.name !== "RateLimitError") {
+    return backoffMs;
+  }
+
+  const resetTime = (error as RateLimitError).resetTime;
+  if (!(resetTime instanceof Date) || Number.isNaN(resetTime.getTime())) {
+    return backoffMs;
+  }
+
+  const waitMs = resetTime.getTime() - now;
+  if (waitMs > maxWaitMs) {
+    return undefined;
+  }
+
+  // A reset that already elapsed should not shorten the normal backoff.
+  return Math.max(waitMs, backoffMs);
 }
 
 export function computeRateLimitReset(


### PR DESCRIPTION
## Summary

`handleResponseError` parses the rate-limit reset onto `RateLimitError.resetTime`, and 3.0.0 fixed that parsing so `Retry-After` deltas read correctly. Nothing consumes it. The retry loop always sleeps `retryDelay * 2 ** attempt`, so a `429` asking for 20s is retried at 1s, 2s and 4s, and all three land inside the window the server told us to sit out.

[Rate Limits → Handling Limits](https://docs.elfa.ai/rate-limits/) tells integrators the opposite:

> Honor `Retry-After` when present; otherwise start with a short delay and increase exponentially.

`HttpClient` only does the "otherwise" half.

## Reproduction

Local server returns `429` with `retry-after` until the limit lifts at 20s, then `200`. Default options, `retries` and `retryDelay` untouched.

```
before                              after
request 1   0.01s   429             request 1   0.01s   429
request 2   1.02s   429             request 2  20.02s   200, data
request 3   3.03s   429
request 4   7.04s   429             2 requests, resolves
throws RateLimitError
```

Retry waits now go through `resolveRetryWait`, which prefers the server's reset over the backoff, never lets an already elapsed reset shorten the backoff, and stops retrying when the reset is further out than `MAX_RATE_LIMIT_WAIT_MS` (60s) rather than blocking the caller for an hour. `resetTime` is public, so a caller can act on it themselves, as the README's error-handling example shows.

With no rate-limit headers on the response, `resetTime` is `undefined` and behaviour is unchanged.

## Testing

141 tests pass (9 added), typecheck, lint, format and build clean.

`MAX_RATE_LIMIT_WAIT_MS` at 60s is a judgement call, and a `429` asking for exactly 60s sits on the boundary. Happy to lower it or expose it as an option if you would rather it were configurable.
