### PR TITLE
fix(types): align mention type and key-status with swagger.json

### DIFF
--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -1,0 +1,66 @@
+import type {
+  ApiKeyStatus,
+  MentionType,
+  ProcessedMention,
+  TopMentionV2,
+} from "../types/elfa";
+
+// Compile-time assertions. `@ts-expect-error` fails the build when the
+// expression it guards stops being an error, so these are real checks.
+
+describe("response types match swagger.json", () => {
+  it("accepts every mention type the schema enumerates", () => {
+    const types: MentionType[] = [
+      "repost",
+      "post",
+      "quote",
+      "reply",
+      "note",
+      "article",
+    ];
+    expect(types).toHaveLength(6);
+  });
+
+  it("rejects a mention type the schema does not enumerate", () => {
+    // @ts-expect-error "tweet" is not in the schema's enum
+    const invalid: MentionType = "tweet";
+    expect(invalid).toBe("tweet");
+  });
+
+  it("narrows `type` on both mention shapes", () => {
+    const mention: Pick<ProcessedMention, "type"> = { type: "quote" };
+    const top: Pick<TopMentionV2, "type"> = { type: "article" };
+
+    // @ts-expect-error `type` is no longer a plain string
+    const loose: Pick<ProcessedMention, "type"> = { type: "whatever" };
+
+    expect([mention.type, top.type, loose.type]).toEqual([
+      "quote",
+      "article",
+      "whatever",
+    ]);
+  });
+
+  it("exposes the key-status fields the schema documents", () => {
+    const status: Partial<ApiKeyStatus> = {
+      key: "elfa_...",
+      requestsPerMinute: 60,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      email: "dev@example.com",
+      project: "example",
+      tier: "free",
+      billingMode: "deposit",
+      depositCredits: 0,
+      allowOverage: false,
+      maxOverage: 0,
+    };
+
+    expect(Object.keys(status)).toHaveLength(10);
+  });
+
+  it("narrows `billingMode` to the documented enum", () => {
+    // @ts-expect-error "invoice" is not in the schema's enum
+    const status: Partial<ApiKeyStatus> = { billingMode: "invoice" };
+    expect(status.billingMode).toBe("invoice");
+  });
+});

--- a/src/types/elfa.ts
+++ b/src/types/elfa.ts
@@ -7,12 +7,22 @@ export interface PingResponse {
 
 export interface ApiKeyStatus {
   id: number;
+  key?: string;
   name: string;
   status: "active" | "revoked" | "expired" | "payment_required";
   dailyRequestLimit: number;
   monthlyRequestLimit: number;
+  requestsPerMinute?: number;
   expiresAt: string;
   createdAt: string;
+  updatedAt?: string;
+  email?: string;
+  project?: string;
+  tier?: string;
+  billingMode?: "deposit" | "arrears";
+  depositCredits?: number;
+  allowOverage?: boolean;
+  maxOverage?: number;
   usage: {
     monthly: number;
     daily: number;
@@ -83,6 +93,9 @@ export interface AccountSmartStatsResponse {
   };
 }
 
+export type MentionType =
+  "repost" | "post" | "quote" | "reply" | "note" | "article";
+
 export interface ProcessedMention {
   tweetId: string;
   link: string;
@@ -93,7 +106,7 @@ export interface ProcessedMention {
   replyCount: number | null;
   bookmarkCount: number | null;
   mentionedAt: string;
-  type: string;
+  type: MentionType;
   account?: {
     isVerified: boolean;
     username: string;
@@ -149,7 +162,7 @@ export interface TopMentionV2 {
   replyCount: number;
   bookmarkCount: number;
   mentionedAt: string;
-  type: string;
+  type: MentionType;
   account?: {
     isVerified: boolean;
     username: string;


### PR DESCRIPTION
Follow-up to #84. Two places the sweep missed.

## `type` is an enum, not a string

`keyword-mentions`, `token-news` and `top-mentions` all enumerate it identically:

```json
"type": { "enum": ["repost", "post", "quote", "reply", "note", "article"] }
```

`ProcessedMention.type` and `TopMentionV2.type` were `string`, so a `switch` over them had no exhaustiveness checking and a typo passed silently. Extracted as an exported `MentionType`.

This reads as an oversight rather than a deliberate widening: `elfa.ts` already narrows every other documented enum (`status`, `chain`, `timeFrame`), and the emitted `.d.ts` narrows `type` on all ten `ChatStreamEvent` variants. These two were the only ones left as `string`.

## `ApiKeyStatus` was missing ten documented fields

The schema documents 21 fields, the interface declared 11. Added the rest:

```
key, updatedAt, requestsPerMinute, email, project,
tier, billingMode, depositCredits, allowOverage, maxOverage
```

`requestsPerMinute` is the one worth calling out, since it is the per-key rate limit and callers currently have to cast to read it. `billingMode` is narrowed to `deposit | arrears` per the schema.

They are optional rather than required because `ApiKeyStatusResponse.data` is a union with `ApiKeyStatusData`, so the payload clearly varies by plan and marking them required would over-promise on a shape I cannot verify. Say the word if the response is invariant and I will make them required.

`ApiKeyStatusData` is left alone. It does not appear in `swagger.json` at all, so there is nothing to align it against, and I would rather not guess.

## Testing

Type-only, no runtime change. Assertions added with `@ts-expect-error` so the build fails if either narrowing regresses.

137 tests pass, typecheck, lint, format and build clean. Verified `swagger.json` is byte-identical to the live spec at `docs.elfa.ai/swagger/swagger.json` before starting.