### PR TITLE
chore: publish as Elfa AI

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "sdk",
     "typescript"
   ],
-  "author": "Elfa Team",
+  "author": "Elfa AI",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Aligns the npm publisher name with the rest of the public packages.

## Changed

| | Was | Now |
| --- | --- | --- |
| `package.json` `author` | `Elfa Team` | `Elfa AI` |

`Elfa AI` is what the Python SDK already publishes as, and what the Cursor plugin manifests use. `LICENSE` in this repo already reads `Elfa AI`, so `package.json` was the last holdout.

npm version metadata is immutable, so this applies from the next release onward. Published versions keep their existing `author` value. Nothing about installs, ownership, trusted publishing or provenance changes — `author` is display metadata only.

## Verification

- `npm run quality` — lint, type-check and format check all green
